### PR TITLE
Added abstol functionality

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,4 +3,4 @@
 immutable SSRootfind{F} <: SteadyStateDiffEqAlgorithm
   nlsolve::F
 end
-SSRootfind(;nlsolve=(f,u0) -> (res=NLsolve.nlsolve(f,u0);res.zero)) = SSRootfind(nlsolve)
+SSRootfind(;nlsolve=(f,u0,abstol) -> (res=NLsolve.nlsolve(f,u0,ftol = abstol);res.zero)) = SSRootfind(nlsolve)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,4 +1,4 @@
-function solve(prob::AbstractSteadyStateProblem,alg::SteadyStateDiffEqAlgorithm,abstol=1e-8,args...;kwargs...)
+function solve(prob::AbstractSteadyStateProblem,alg::SteadyStateDiffEqAlgorithm,args...;abstol=1e-8,kwargs...)
 
   if prob.mass_matrix != I
     error("This solver is not able to use mass matrices.")

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,4 +1,4 @@
-function solve(prob::AbstractSteadyStateProblem,alg::SteadyStateDiffEqAlgorithm,args...;kwargs...)
+function solve(prob::AbstractSteadyStateProblem,alg::SteadyStateDiffEqAlgorithm,abstol=1e-8,args...;kwargs...)
 
   if prob.mass_matrix != I
     error("This solver is not able to use mass matrices.")
@@ -27,7 +27,7 @@ function solve(prob::AbstractSteadyStateProblem,alg::SteadyStateDiffEqAlgorithm,
   # f = (u) -> (f!(du,u); du) # out-of-place version
 
   if typeof(alg) <: SSRootfind
-    u = alg.nlsolve(f!,u0)
+    u = alg.nlsolve(f!,u0,abstol)
     resid = similar(u)
     f!(u,resid)
     build_solution(prob,alg,u,resid;retcode = :Success)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ f(0,sol.u,du)
 @test du == [0,0]
 
 # Use Sundials
-sol = solve(prob,SSRootfind(nlsolve = (f,u0,abstol) -> (res=Sundials.kinsol(f,u0);res.zero) ))
+sol = solve(prob,SSRootfind(nlsolve = (f,u0,abstol) -> (res=Sundials.kinsol(f,u0)) ))
 
 f(0,sol.u,du)
 @test du == [0,0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ f(0,sol.u,du)
 @test du == [0,0]
 
 # Use Sundials
-sol = solve(prob,SSRootfind(nlsolve = Sundials.kinsol))
+sol = solve(prob,SSRootfind(nlsolve = (f,u0,abstol) -> (res=Sundials.kinsol(f,u0);res.zero) ))
 
 f(0,sol.u,du)
 @test du == [0,0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ function f(t,u,du)
 end
 u0 = zeros(2)
 prob = SteadyStateProblem(f,u0)
-
+abstol = 1e-8
 sol = solve(prob,SSRootfind())
 
 du = zeros(2)
@@ -16,7 +16,7 @@ f(0,sol.u,du)
 
 prob = ODEProblem(f,u0,(0.0,1.0))
 prob = SteadyStateProblem(prob)
-sol = solve(prob,SSRootfind(nlsolve = (f,u0) -> (res=NLsolve.nlsolve(f,u0,autodiff=true,method=:newton,iterations=Int(1e6));res.zero) ))
+sol = solve(prob,SSRootfind(nlsolve = (f,u0,abstol) -> (res=NLsolve.nlsolve(f,u0,autodiff=true,method=:newton,iterations=Int(1e6),ftol=abstol);res.zero) ))
 
 f(0,sol.u,du)
 @test du == [0,0]


### PR DESCRIPTION
I have added some functionality of abstol.
with referrence to issue [#228](https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/228) 
`solve(prob,SSRootfind(),abstol=1e-6)`
`solve(prob,SSRootfind())` for default method
I have tried out a few simple examples but the results were preety same for both the methods. 
Please do let me know if further changes are required.